### PR TITLE
fix(android): remove jcenter repository for AGP 9 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
## Summary
- Removes deprecated `jcenter()` repository from `android/build.gradle`
- Fixes Android builds with AGP 9, which no longer supports jcenter

Closes #3

## Test plan
- [x] Verified `jcenter()` is removed from `android/build.gradle`
- [ ] CI `bun run verify` passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency sources to use modern repositories only, improving build reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->